### PR TITLE
Update shutdown script to use interrupts

### DIFF
--- a/Sleepy-Pi-Setup.sh
+++ b/Sleepy-Pi-Setup.sh
@@ -145,7 +145,7 @@ if grep -q 'shutdowncheck.py' /etc/rc.local; then
 else
     [ ! -d /home/pi/bin  ] && mkdir /home/pi/bin
     [ ! -d /home/pi/bin/SleepyPi  ] && mkdir /home/pi/bin/SleepyPi
-    wget https://raw.githubusercontent.com/SpellFoundry/Sleepy-Pi-Setup/master/shutdowncheck.py
+    wget https://raw.githubusercontent.com/PhilipMathieu/Sleepy-Pi-Setup/master/shutdowncheck.py
     mv -f shutdowncheck.py /home/pi/bin/SleepyPi
     sed -i '/exit 0/i python /home/pi/bin/SleepyPi/shutdowncheck.py &' /etc/rc.local
     # echo "python /home/pi/bin/SleepyPi/shutdowncheck.py &" | sudo tee -a /etc/rc.local

--- a/shutdowncheck.py
+++ b/shutdowncheck.py
@@ -4,14 +4,15 @@ import RPi.GPIO as GPIO
 import os, time
 
 GPIO.setmode(GPIO.BCM)
-GPIO.setup(24, GPIO.IN)
+GPIO.setup(24, GPIO.IN, pull_up_down=GPIO.PUD_DOWN)
 GPIO.setup(25, GPIO.OUT)
 GPIO.output(25, GPIO.HIGH)
 print ("[Info] Telling Sleepy Pi we are running pin 25")
 
-while True:
-	if (GPIO.input(24)):
-		print ("Sleepy Pi requesting shutdown on pin 24")
-		os.system("sudo shutdown -h now")
-		break
-	time.sleep(0.5)
+try:
+    GPIO.wait_for_edge(24, GPIO.RISING)
+    print "Rising edge detected on port 24. Here endeth the third lesson."
+    os.system("sudo shutdown -h now")
+except KeyboardInterrupt:
+    pass       
+GPIO.cleanup() # clean up GPIO on exit 

--- a/shutdowncheck.py
+++ b/shutdowncheck.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 import RPi.GPIO as GPIO
-import os, time
+import os
 
 GPIO.setmode(GPIO.BCM)
 GPIO.setup(24, GPIO.IN, pull_up_down=GPIO.PUD_DOWN)
@@ -11,8 +11,8 @@ print ("[Info] Telling Sleepy Pi we are running pin 25")
 
 try:
     GPIO.wait_for_edge(24, GPIO.RISING)
-    print "Rising edge detected on port 24. Here endeth the third lesson."
+    print ("Sleepy Pi requesting shutdown on pin 24")
     os.system("sudo shutdown -h now")
 except KeyboardInterrupt:
     pass       
-GPIO.cleanup() # clean up GPIO on exit 
+GPIO.cleanup()


### PR DESCRIPTION
Takes advantage of the recent upgrades to the RPi.GPIO library that allows easy implementation of interrupts, thus removing the need for an infinite loop and clunky time.sleep() calls