### PR TITLE
Set core_freq to 400 on RPi3

### DIFF
--- a/Sleepy-Pi-Setup.sh
+++ b/Sleepy-Pi-Setup.sh
@@ -86,13 +86,15 @@ if [ $RPi3 = true ]; then
     if grep -q 'core_freq=400' /boot/config.txt; then
         echo 'The frequency of GPU processor core is set to 400MHz already - skipping'
     else
-        echo 'core_freq=400' | sudo tee -a /boot/config.txt
+        echo 'Setting core_freq=400 in /boot/config.txt'
+        sed -i 's/^core_freq=.*/core_freq=400/g' /boot/config.txt
         fi
     else
         if grep -q 'core_freq=250' /boot/config.txt; then
             echo 'The frequency of GPU processor core is set to 250MHz already - skipping'
         else
-            echo 'core_freq=250' | sudo tee -a /boot/config.txt
+            echo 'Setting core_freq=250 in /boot/config.txt'
+            sed -i 's/^core_freq=.*/core_freq=250/g' /boot/config.txt
             fi
         fi
 

--- a/Sleepy-Pi-Setup.sh
+++ b/Sleepy-Pi-Setup.sh
@@ -82,11 +82,20 @@ if grep -q 'enable_uart=1' /boot/config.txt; then
 else
     echo 'enable_uart=1' | sudo tee -a /boot/config.txt
 fi
-if grep -q 'core_freq=250' /boot/config.txt; then
-    echo 'The frequency of GPU processor core is set to 250MHz already - skipping'
-else
-    echo 'core_freq=250' | sudo tee -a /boot/config.txt
-fi
+if [ $RPi3 != true ]; then
+    if grep -q 'core_freq=400' /boot/config.txt; then
+        echo 'The frequency of GPU processor core is set to 400MHz already - skipping'
+    else
+        echo 'core_freq=400' | sudo tee -a /boot/config.txt
+        fi
+    else
+        if grep -q 'core_freq=250' /boot/config.txt; then
+            echo 'The frequency of GPU processor core is set to 250MHz already - skipping'
+        else
+            echo 'core_freq=250' | sudo tee -a /boot/config.txt
+            fi
+        fi
+
 
 ## Disable Serial login
 echo 'Disabling Serial Login...'

--- a/Sleepy-Pi-Setup.sh
+++ b/Sleepy-Pi-Setup.sh
@@ -83,14 +83,14 @@ else
     echo 'enable_uart=1' | sudo tee -a /boot/config.txt
 fi
 if [ $RPi3 = true ]; then
-    if grep -q 'core_freq=400' /boot/config.txt; then
+    if grep -q '^core_freq=400' /boot/config.txt; then
         echo 'The frequency of GPU processor core is set to 400MHz already - skipping'
     else
         echo 'Setting core_freq=400 in /boot/config.txt'
         sed -i 's/^core_freq=.*/core_freq=400/g' /boot/config.txt
         fi
     else
-        if grep -q 'core_freq=250' /boot/config.txt; then
+        if grep -q '^core_freq=250' /boot/config.txt; then
             echo 'The frequency of GPU processor core is set to 250MHz already - skipping'
         else
             echo 'Setting core_freq=250 in /boot/config.txt'

--- a/Sleepy-Pi-Setup.sh
+++ b/Sleepy-Pi-Setup.sh
@@ -82,7 +82,7 @@ if grep -q 'enable_uart=1' /boot/config.txt; then
 else
     echo 'enable_uart=1' | sudo tee -a /boot/config.txt
 fi
-if [ $RPi3 != true ]; then
+if [ $RPi3 = true ]; then
     if grep -q 'core_freq=400' /boot/config.txt; then
         echo 'The frequency of GPU processor core is set to 400MHz already - skipping'
     else


### PR DESCRIPTION
According to [the docs](https://www.raspberrypi.org/documentation/configuration/config-txt/overclocking.md), core_freq should default to 400 on the RPi 3.

Added a conditional check that sets the correct value if we are installing on an RPi3.