### PR TITLE
Added compatibility with the 3B+, 3A+, and Zero W

### DIFF
--- a/Sleepy-Pi-Setup.sh
+++ b/Sleepy-Pi-Setup.sh
@@ -41,6 +41,15 @@ elif [ "$RpiCPU" == "a22082" ]; then
 elif [ "$RpiCPU" == "a32082" ]; then
     echo "RapberryPi 3 detected"
     RPi3=true
+elif [ "$RpiCPU" == "a020d3" ]; then
+    echo "RapberryPi 3 B+ detected"
+    RPi3=true
+elif [ "$RpiCPU" == "9020e0" ]; then
+    echo "RapberryPi 3 A+ detected"
+    RPi3=true
+elif [ "$RpiCPU" == "9000c1" ]; then
+    echo "RapberryPi Zero W detected"
+    RPi3=true
 else
     # RaspberryPi 2 or 1... let's say it's 2...
     echo "Non-RapberryPi 3 detected"


### PR DESCRIPTION
The Raspberry Pi 3B+, 3A+, and Zero W contain the same bluetooth module
as the original Raspberry Pi 3, which means they use the same serial port
configuration. The Sleepy-Pi-Setup.sh script did not account for this
and would incorrectly set up the serial port used to program the Sleepy Pi 2.

The Sleepy-Pi-Setup.sh script was modified to configure
the ttyS0 serial port on these boards, instead of the ttyAMA0 serial
port.