### PR TITLE
Edit rc.local

### DIFF
--- a/Sleepy-Pi-Setup.sh
+++ b/Sleepy-Pi-Setup.sh
@@ -183,6 +183,7 @@ else
     mkdir -p /home/pi/bin/SleepyPi
     wget https://raw.githubusercontent.com/SpellFoundry/Sleepy-Pi-Setup/master/shutdowncheck.py
     mv -f shutdowncheck.py /home/pi/bin/SleepyPi
+    sed -i '/"exit 0"/g' /etc/rc.local
     sed -i '/exit 0/i python /home/pi/bin/SleepyPi/shutdowncheck.py &' /etc/rc.local
     # echo "python /home/pi/bin/SleepyPi/shutdowncheck.py &" | sudo tee -a /etc/rc.local
 fi


### PR DESCRIPTION
As there are two occurrences of  exit 0 - one in the original header of the file in " " and the other one on the end - the shutdownchek.py will run twice. Just remove the "exit 0" from the comment area with another sed command.

Maybe there is a better way to filter the last match of exit 0. 