### PR TITLE
Bookworm compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sleepy-Pi-Setup.sh
 
 
-Currently this works with Raspbian Jessie, Stretch or Buster and "pi" user at this time. 
+Currently this works with Raspbian Jessie, Stretch, Buster and Bookworm, with any user name. 
 
 1. To setup from a fresh Raspbian image, first download a full Jessie image from [Raspberry Pi downloads] and flash it onto an SD Card.
 


### PR DESCRIPTION
I've fixed the setup.sh to work with the bookworm version of the RaspberryPi OS. You can use any username you want and it's backwards compatible with the older version. For https://github.com/SpellFoundry/Sleepy-Pi-Setup/issues/22#issue-1349672682 I've also added a prompt to skip the Arduino install and another prompt to skip the library install.
Not tested but should work